### PR TITLE
Require luaunit based on their example

### DIFF
--- a/tests/testAssignment.lua
+++ b/tests/testAssignment.lua
@@ -1,7 +1,9 @@
 package.path = package.path .. ";../src/?.lua;"
 local Assignment = require "assignment"
 
-local LuaUnit = require "resources.luaunit"
+EXPORT_ASSERT_TO_GLOBALS = true
+require("resources.luaunit")
+
 TestAssignment = {}
 
 local testerUnit = '4'
@@ -49,4 +51,5 @@ function TestAssignment:work_with_falsy_overrides()
   -- expect(a.get('z')).toEqual(false);
 end
 
-LuaUnit:run()
+local lu = LuaUnit.new()
+os.exit( lu:runSuite() )


### PR DESCRIPTION
Use the method of requiring that is shown in their example, rather than the (what looks to be cleaner) `local` version.
